### PR TITLE
Syntax highlighting support for underscore-identified JSX attributes

### DIFF
--- a/grammars/cjsx.json
+++ b/grammars/cjsx.json
@@ -115,7 +115,7 @@
     },
     "jsx-tag-attribute-name": {
       "name": "meta.tag.attribute-name.coffee",
-      "match": "\\b([a-zA-Z\\-:]+)",
+      "match": "\\b([a-zA-Z\\$_]\\w*(\\.\\w+)*)",
       "captures": {
         "1": {
           "name": "entity.other.attribute-name.coffee"


### PR DESCRIPTION
Under the current release, syntax highlighting of underscore-identified JSX attributes is broken:

![screen shot 2015-06-04 at 5 50 39 pm](https://cloud.githubusercontent.com/assets/45365/7995419/903bb4be-0ae3-11e5-80dc-8b44dc7c7290.png)

This pull request leverages the same regular expression pattern used for variable assignment to get it looking right.

![screen shot 2015-06-04 at 6 01 15 pm](https://cloud.githubusercontent.com/assets/45365/7995431/b7e38744-0ae3-11e5-9212-281fb60396a1.png)
